### PR TITLE
Remove AnalyticZ integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,8 +96,7 @@ params:
   analytics:
     google:
       SiteVerificationTag: "i_X2zxbHkmFz5EuSN1p37tKal2UF4ZxpA7QN4hZ-CIY"
-    analyticsz:
-      ID: "ZwSg9rf6GA"
+
   #   bing:
   #     SiteVerificationTag: "XYZabc"
   #   yandex:

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -11,7 +11,7 @@ This website is built using Hugo and hosted on Github Pages. This is a simple st
 
 ## Analytics
 
-This website does not use any analytics or tracking services.
+This website does not use any analytics or tracking services at the moment.
 
 ## Contact
 

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -11,36 +11,7 @@ This website is built using Hugo and hosted on Github Pages. This is a simple st
 
 ## Analytics
 
-This website uses AnalyticsZ, a privacy-focused web analytics service, to understand how visitors use the site and improve your experience. AnalyticsZ is designed to be compliant with GDPR, PECR, and other privacy regulations.
-
-### What data is collected
-
-AnalyticsZ collects limited, anonymous usage data including:
-- Pages you visit on this website (page URLs)
-- How you arrived at the site (referring website)
-- Your country (derived from anonymised IP address - your full IP is never stored)
-- Browser type and version
-- Device type
-
-All data is aggregated and anonymised, ensuring it cannot be traced back to you as an individual user.
-
-### How your privacy is protected
-
-- **No cookies:** AnalyticsZ does not use cookies or similar tracking technologies
-- **No personal data:** No personally identifiable information is collected
-- **IP anonymisation:** Your IP address is anonymised immediately and never stored in full
-- **Aggregated data only:** All analytics data is aggregated and cannot identify individual users
-- **GDPR compliant:** AnalyticsZ is designed to be fully GDPR-compliant
-
-### Legal basis
-
-We process this analytics data based on our legitimate interest in understanding how our website is used and improving the user experience, as permitted under Article 6(1)(f) of UK GDPR.
-
-### Your rights
-
-While UK GDPR provides rights such as data access, deletion, and objection to processing, these are not applicable here as AnalyticsZ does not collect personally identifiable information. If you have any concerns about privacy, you can contact me through the [contact page](/contact).
-
-For more information about how AnalyticsZ handles data, see their [Privacy Policy](https://analyticsz.com/pages/privacy-policy).
+This website does not use any analytics or tracking services.
 
 ## Contact
 

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,10 +1,3 @@
 {{- /* Head custom content area start */ -}}
 
-{{- if hugo.IsProduction }}
-{{- with site.Params.analytics.analyticsz.ID }}
-<!-- AnalyticsZ Analytics -->
-<script data-host="https://analyticsz.com" data-dnt="false" src="https://analyticsz.com/js/script.js" id="{{ . }}" async defer></script>
-{{- end }}
-{{- end }}
-
 {{- /* Head custom content area end */ -}}


### PR DESCRIPTION
Removes the AnalyticZ analytics integration that had stopped working:

- Remove the AnalyticZ script from `layouts/partials/extend_head.html`
- Remove the `analyticsz` config block from `config.yaml`
- Update the privacy policy to state the site no longer uses analytics

Build verified with `hugo --buildDrafts`.