### PR TITLE
fix: remove responsiveImages to fix mixed content issue with cover image

### DIFF
--- a/content/blog/2026-08-02-using-ai-to-publish-not-to-create/index.md
+++ b/content/blog/2026-08-02-using-ai-to-publish-not-to-create/index.md
@@ -3,7 +3,6 @@ title: "Using AI to Publish, Not to Create"
 date: 2026-08-02T00:00:00Z
 tags: ["AI", "Blogging", "Hermes Agent"]
 cover:
-    responsiveImages: true
     relative: true
     image: "images/featured.jpg"
     alt: "Dan sitting in the garden with his phone, showing he can publish blog posts from anywhere"


### PR DESCRIPTION
The cover image was not loading because responsiveImages: true caused Hugo to generate absolute http:// URLs for the responsive image variants, but the site is served over https://. The browser blocks the mixed content. Removing responsiveImages fixes it.