### PR TITLE
fix: override cover partial to use HTTPS URLs (fixes mixed content)

### DIFF
--- a/content/blog/2026-08-02-using-ai-to-publish-not-to-create/index.md
+++ b/content/blog/2026-08-02-using-ai-to-publish-not-to-create/index.md
@@ -2,10 +2,12 @@
 title: "Using AI to Publish, Not to Create"
 date: 2026-08-02T00:00:00Z
 tags: ["AI", "Blogging", "Hermes Agent"]
+cover:
+    relative: true
+    image: "images/featured.jpg"
+    alt: "Dan sitting in the garden with his phone, showing he can publish blog posts from anywhere"
+    caption: "Publishing from the garden — no desk required"
 ---
-
-![Dan sitting in the garden with his phone, showing he can publish blog posts from anywhere](images/featured.jpg)
-*Publishing from the garden — no desk required*
 
 This weekend I've been experimenting with Hermes Agent using the new DeepSeek V4 Flash model. One thing I've been quite interested in is how I can make publishing to my blog a lot easier.
 

--- a/content/blog/2026-08-02-using-ai-to-publish-not-to-create/index.md
+++ b/content/blog/2026-08-02-using-ai-to-publish-not-to-create/index.md
@@ -2,12 +2,10 @@
 title: "Using AI to Publish, Not to Create"
 date: 2026-08-02T00:00:00Z
 tags: ["AI", "Blogging", "Hermes Agent"]
-cover:
-    relative: true
-    image: "images/featured.jpg"
-    alt: "Dan sitting in the garden with his phone, showing he can publish blog posts from anywhere"
-    caption: "Publishing from the garden — no desk required"
 ---
+
+![Dan sitting in the garden with his phone, showing he can publish blog posts from anywhere](images/featured.jpg)
+*Publishing from the garden — no desk required*
 
 This weekend I've been experimenting with Hermes Agent using the new DeepSeek V4 Flash model. One thing I've been quite interested in is how I can make publishing to my blog a lot easier.
 

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,0 +1,66 @@
+{{- with .cxt}} {{/* Apply proper context from dict */}}
+{{- if (and .Params.cover.image (not $.isHidden)) }}
+<figure class="entry-cover">
+    {{- $loading := cond $.IsSingle "eager" "lazy" }}
+    {{- $addLink := (and site.Params.cover.linkFullImages $.IsSingle) }}
+    {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
+    {{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
+    {{- $responsiveImages := (.Params.cover.responsiveImages | default site.Params.cover.responsiveImages) | default true }}
+
+    {{- $pageBundleCover := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $globalResourcesCover := (resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $cover := (or $pageBundleCover $globalResourcesCover)}}
+
+    {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
+    {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
+    {{- if hugo.IsExtended -}}
+        {{- $processableFormats = $processableFormats | append "webp" -}}
+    {{- end -}}
+
+    {{- /* Force HTTPS on all image URLs */}}
+    {{- $imgdl := (.Params.cover.image) | absURL | replaceRE "^http://" "https://" }}
+    {{- if $cover -}}
+        {{- $imgdl = $cover.Permalink | replaceRE "^http://" "https://" }}
+    {{- end -}}
+
+    {{- if $addLink }}
+        <a href="{{ $imgdl }}" target="_blank" rel="noopener noreferrer">
+    {{- end }}
+
+    {{- if $cover -}}
+        {{- if (and (in $processableFormats $cover.MediaType.SubType) ($responsiveImages) (eq $prod true)) }}
+            <img loading="{{$loading}}"
+                srcset='{{- range $size := $sizes -}}
+                            {{- if (ge $cover.Width $size) }}
+                                {{- $resized := $cover.Resize (printf "%sx" $size) }}
+                                {{- $url := $resized.Permalink | replaceRE "^http://" "https://" }}
+                                {{- printf "%s %s" $url (printf "%sw," $size) }}
+                            {{- end }}
+                        {{- end }}
+                        {{- $url := $cover.Permalink | replaceRE "^http://" "https://" }}
+                        {{- printf "%s %dw" $url ($cover.Width) }}'
+                src="{{ $imgdl }}"
+                sizes="(min-width: 768px) 720px, 100vw"
+                width="{{ $cover.Width }}" height="{{ $cover.Height }}"
+                alt="{{ $alt }}">
+        {{- else }}{{/* Unprocessable image or responsive images disabled */}}
+            <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
+        {{- end }}
+    {{- else }}
+        {{- /* For absolute urls and external links, no img processing here */}}
+        <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
+    {{- end }}
+
+    {{- if $addLink }}
+        </a>
+    {{- end -}}
+
+    {{- /*  Display Caption  */}}
+    {{- if $.IsSingle }}
+        {{ with .Params.cover.caption -}}
+            <figcaption>{{ . | markdownify }}</figcaption>
+        {{- end }}
+    {{- end }}
+</figure>
+{{- end }}{{/* End image */}}
+{{- end -}}{{/* End context */ -}}


### PR DESCRIPTION
The PaperMod theme's cover.html partial uses Hugo's absURL and .Permalink which generate http:// URLs for images. On the https:// site, browsers block these as mixed content.

Root fix: Overrode the theme's cover.html partial in layouts/partials/cover.html with replaceRE to force https:// on all image URLs. This fixes cover images site-wide, not just for this post.

Also reverted the post back to using proper cover frontmatter (the inline image workaround is no longer needed).