### PR TITLE
feat: add xquote shortcode - cookie-free X/Twitter embeds

### DIFF
--- a/layouts/shortcodes/xquote.html
+++ b/layouts/shortcodes/xquote.html
@@ -1,0 +1,19 @@
+{{- $user := .Get "user" | default "" -}}
+{{- $id := .Get "id" | default "" -}}
+{{- if and $user $id -}}
+  {{- $url := printf "https://x.com/%v/status/%v" $user $id -}}
+  {{- $query := querify "url" $url "dnt" true "omit_script" true -}}
+  {{- $request := printf "https://publish.x.com/oembed?%s" $query -}}
+  {{- with try (resources.GetRemote $request) -}}
+    {{- with .Err -}}
+      {{- warnidf "xquote-getremote" "The %q shortcode was unable to retrieve the tweet: %s. See %s" $.Name . $.Position -}}
+    {{- else with .Value -}}
+      {{- $data := . | transform.Unmarshal -}}
+      {{- $data.html | safeHTML -}}
+    {{- else -}}
+      {{- warnidf "xquote-getremote" "The %q shortcode was unable to retrieve the tweet. See %s" $.Name $.Position -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- errorf "The %q shortcode requires two named parameters: user and id. See %s" .Name .Position -}}
+{{- end -}}


### PR DESCRIPTION
## What

Adds an `xquote` shortcode for embedding X/Twitter posts **without any cookies or third-party scripts** — the site currently places no cookies, and this preserves that (GDPR-friendly).

## How it works

- The tweet is fetched **once at build time** via X's oEmbed API (`https://publish.x.com/oembed?omit_script=true`)
- The resulting HTML (blockquote + link) is baked into the static page
- **No `widgets.js`, no client-side script, no cookies, no tracking**

## Why not the built-in shortcode

Hugo's built-in `{{< x >}}` shortcode loads `platform.x.com/widgets.js` on the client — that script sets cookies (GDPR concern). Hugo's `{{< x_simple >}}` variant is cookie-free but injects its own inline CSS (grey `#555` text) that clashes with the site's dark theme.

`xquote` reuses the site's native blockquote styling instead — verified rendering in dark mode on desktop + mobile.

## Usage

```md
{{< xquote user="levelsio" id="2084348044808507416" >}}
```

## Verified

- Builds clean with Hugo 0.164 (the version the site's CI uses)
- Renders correctly in dark theme, desktop + mobile (screenshots in PR review)
- No external `<script>` tags in output